### PR TITLE
Adding convergents based search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+CC=gcc
+L=-lm -lgmp
+
+default: cf_convergents.c
+	$(CC) cf_convergents.c $(L) -o convergents
+

--- a/cf_convergents.c
+++ b/cf_convergents.c
@@ -1,0 +1,81 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <gmp.h>
+
+mpz_t temp_h;
+mpz_t temp_k;
+mpf_t temp_f;
+mpf_t temp_f2;
+
+void get_cf(mpf_t r, mpz_t h, mpz_t k, mpz_t h_old, mpz_t k_old, mpz_t a){
+	mpz_set_f(a, r);
+	mpf_set_z(temp_f, a);
+	mpf_sub(r, r, temp_f);
+	mpf_ui_div(r, 1, r);
+
+	mpz_mul(temp_h, a, h);
+	mpz_add(temp_h, temp_h, h_old);
+	mpz_mul(temp_k, a, k);
+	mpz_add(temp_k, temp_k, k_old);
+
+	mpz_set(h_old, h);
+	mpz_set(k_old, k);
+	mpz_set(h, temp_h);
+	mpz_set(k, temp_k);
+}
+
+int main(int argc, char **argv){
+	mpf_t r;
+	mpz_t h;
+	mpz_t k;
+	mpz_t h_old;
+	mpz_t k_old;
+	mpz_t a;
+	int i;
+	double d;
+
+	if(argc > 1){
+		//Allow the user to specify a default precision using a command-line argument
+		mpf_set_default_prec(atoi(argv[1]));
+	}
+
+	mpf_init(r);
+	mpf_init(temp_f);
+	mpf_init(temp_f2);
+
+	mpz_init(temp_h);
+	mpz_init(temp_k);
+	mpz_init(h);
+	mpz_init(k);
+	mpz_init(h_old);
+	mpz_init(k_old);
+	mpz_init(a);
+
+	mpf_set_d(r, M_PI/2);
+
+	mpz_set_si(h, 1);
+	mpz_set_si(k_old, 1);
+
+	for(i = 0; i < 10; i++){
+		get_cf(r, h, k, h_old, k_old, a);
+		if(mpz_odd_p(k)){
+			printf("candidate: ");
+			mpz_out_str(stdout, 0, h);
+			printf("\n");
+		}
+	}
+
+	mpf_clear(r);
+	mpf_clear(temp_f);
+	mpf_clear(temp_f2);
+
+	mpz_clear(temp_h);
+	mpz_clear(temp_k);
+	mpz_clear(h);
+	mpz_clear(k);
+	mpz_clear(h_old);
+	mpz_clear(k_old);
+	mpz_clear(a);
+}
+


### PR DESCRIPTION
Hi Matt,

I created some code which searches for integers with |tan(n)| large in a different way. Instead of searching one-by-one through the integers, this code creates the convergents for the continued-fraction expansion of pi/2. By Dirchlet's approximation theorem, each convergent p/q satisfies the inequality |pi/2 - p/q| < 1/q^2. Multiplying both sides by q it's clear that for each convergent, |q\*pi/2 - p| < 1/q. This means that for every convergent with q odd, our numerator p approaches our desired numbers of the form pi + pi/2*n with increasing accuracy. Since |tan(k)| strictly increases as k approaches numbers of the form pi + pi/2\*n, this search yields a sequence of integers k_n for which |tan(k_n)| strictly increases. It just so happens that primality is relevant here! The numerator and denominator of the convergents of the continued fraction must be coprime, which means that good candidates for large primes p with |tan(p)|>p are the numerators that the program outputs for which the denominator had many prime factors!